### PR TITLE
feat: rollback to dotnet 8

### DIFF
--- a/.github/workflows/dan-default-proxy.build-deploy.yml
+++ b/.github/workflows/dan-default-proxy.build-deploy.yml
@@ -13,11 +13,11 @@ permissions:
 
 jobs:
   run:
-    uses: data-altinn-no/deploy-actions/.github/workflows/dan-noslots-deploy-flow.yml@5f9c66f7ba21363553819f102d922c66eae18183
+    uses: data-altinn-no/deploy-actions/.github/workflows/dan-noslots-deploy-flow.yml@009dae7d9c3f0ddab3c1be13fe0c76177e174d74
     with:
       artifact_name: 'dan-proxy-default' # Can be omitted, defaults to 'artifact'
       function_project_path: 'src/Dan.Proxy'
-      dotnet_version: '10.0.x'
+      dotnet_version: '8.0.x'
     secrets:
       function_app_name: ${{ secrets.DEFAULT_PROXY_FUNCTIONAPP_NAME }}
       publish_profile: ${{ secrets.DEFAULT_PROXY_AZURE_FUNCTION_PUBLISH_CREDS }}

--- a/src/Dan.Proxy/Dan.Proxy.csproj
+++ b/src/Dan.Proxy/Dan.Proxy.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
### Description
MS currently seems to have issues with the combination of flex consumption function app, dotnet 10 and linux, which so happens to hit this. Rolling back until they have resolved it

### Documentation
- [ ] Doc updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build toolchain to use .NET 8.0 instead of .NET 10.0 for compilation and deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->